### PR TITLE
Reduce whitespaces in the SCP by making the NotAction lists all in one line

### DIFF
--- a/aws_allowlister/command/generate.py
+++ b/aws_allowlister/command/generate.py
@@ -142,8 +142,20 @@ def generate(all_standards, soc, pci, hipaa, iso, fedramp_high, fedramp_moderate
         logger.info(f"--all was selected. The policy will include the default standard(s): {str(', '.join(standards))}")
     logger.info(f"Note: to silence these logs, supply the argument '--quiet'")
     logger.info(f"Policies for standard(s): {str(', '.join(standards))}")
+
     results = generate_allowlist_scp(standards, include, exclude)
-    print(json.dumps(results, indent=4))
+
+    minified_results = f"""{{
+    "Version": "2012-10-17",
+        "Statement": {{
+            "Sid": "AllowList",
+            "Effect": "Deny",
+            "Resource": "*",
+            "NotAction": {json.dumps(results.get('Statement').get('NotAction'))}
+        }}
+}}"""
+    print(minified_results)
+    # print(json.dumps(results, indent=4))
 
 
 def generate_allowlist_scp(standards, include=None, exclude=None):


### PR DESCRIPTION
## What does this PR do?

It turns this:

![image](https://user-images.githubusercontent.com/3422255/106203163-f774b700-6188-11eb-9b61-e3d325e89cd7.png)


into this:

![image](https://user-images.githubusercontent.com/3422255/106203137-ee83e580-6188-11eb-9a5e-7234bb707506.png)


## What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/3422255/106203206-09565a00-6189-11eb-833d-bbba12465423.png)


## Completion checklist

- [x] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/aws-allowlister/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
