### PR TITLE
Update fedramp.py

### DIFF
--- a/aws_allowlister/scrapers/tables/fedramp.py
+++ b/aws_allowlister/scrapers/tables/fedramp.py
@@ -59,7 +59,7 @@ def scrape_fedramp_table(db_session, link, destination_folder, file_name):
                     )
 
                 # Cell 2: FedRAMP High (GovCloud)
-                fedramp_high_status, fedramp_high_status_contents = clean_status_cell_contents(cells[1].contents[0])
+                fedramp_high_status, fedramp_high_status_contents = clean_status_cell_contents(cells[2].contents[0])
                 if fedramp_high_status:
                     # print(f"fedramp_high_status: {fedramp_moderate_status}, {fedramp_high_status_contents}")
                     raw_scraping_data.add_entry_to_database(


### PR DESCRIPTION
FedRAMP High (GovCloud) was pulling from FedRAMP Moderate (cell[1]) column instead of FedRAMP High (cell[2]).

## What does this PR do?
FedRAMP High scraper was pulling from the wrong column and was listing FedRAMP Moderate services.

## What gif best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/l36kU80xPf0ojG0Erg/giphy.gif)

## Completion checklist

- [ X ] Additions and changes have unit tests
- [ X ] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/aws-allowlister/actions). GitHub actions does this automatically
- [ X ] The pull request has been appropriately labeled using the provided PR labels
