### PR TITLE
Update overrides to include access-analyzer

### DIFF
--- a/aws_allowlister/data/overrides.yml
+++ b/aws_allowlister/data/overrides.yml
@@ -128,6 +128,7 @@ service_names_to_iam_names:
     - dms
   AWS Identity & Access Management:
     - iam
+    - access-analyzer
   Amazon S3 Glacier:
     - glacier
   Amazon Elastic Kubernetes Service:


### PR DESCRIPTION
I was informed by our AWS TAM that [`access-analyzer`](https://docs.aws.amazon.com/service-authorization/latest/reference/list_iamaccessanalyzer.html) is part of IAM and is covered by the same compliance certifications.

## What does this PR do?

Adds `access-analyzer` to overrides for IAM

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/3o7TKqTOqevMiJAwU0/giphy.gif)

## Completion checklist
N/A
- [ ] Additions and changes have unit tests
- [ ] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/aws-allowlister/actions). GitHub actions does this automatically
- [ ] The pull request has been appropriately labeled using the provided PR labels
