### PR TITLE
Fix PyUp with GitHub actions workaround

### DIFF
--- a/.github/workflows/python-dependency-updater.yml
+++ b/.github/workflows/python-dependency-updater.yml
@@ -1,0 +1,27 @@
+name: python-dependency-updater
+
+on:
+  # Run on the first day of the month
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  python-dependency-updater:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7']
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Pyup.io Dependency updater
+        run: |
+          pip install pyupio
+          pip install -r requirements.txt
+          default_branch=`git remote show origin | grep 'HEAD branch' | cut -d' ' -f5`
+          pyup --provider github --provider_url https://api.github.com --repo=$GITHUB_REPOSITORY --user-token=${{ secrets.PYUP_GITHUB_ACCESS_TOKEN }} --branch $default_branch --initial


### PR DESCRIPTION
## What does this PR do?

* Adds workaround for PyUp.io breaking

## What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/3422255/114586591-d7667700-9c52-11eb-8aa2-e98a7c2227e8.png)

## Completion checklist

- [x] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/aws-allowlister/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
