### PR TITLE
Add version bump automation

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,15 @@
+name: Publish
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Bump version
+        run: sh ${GITHUB_WORKSPACE}/utils/bump-version.sh

--- a/utils/bump-version.sh
+++ b/utils/bump-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -ex
+
+version_file="aws_allowlister/bin/version.py"
+repo="salesforce/aws-allowlister"
+# https://github.com/bridgecrewio/checkov/blob/master/.github/workflows/build.yml#L87-L132
+
+git config --local user.email "action@github.com"
+git config --local user.name "GitHub Action"
+git fetch --tags
+latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+echo "latest tag: $latest_tag"
+new_tag=$(echo $latest_tag | awk -F. -v a="$1" -v b="$2" -v c="$3" '{printf("%d.%d.%d", $1+a, $2+b , $3+1)}')
+echo "new tag: $new_tag"
+
+# Update __version__ in python
+echo "__version__ = '$new_tag'" > $version_file
+
+git commit --reuse-message=HEAD@{1} $version_file || echo "No changes to commit"
+git push origin
+# Commenting the rest of this out because we use the release drafter to actually push new tags
+#git tag $new_tag
+#git push origin $new_tag
+#RELEASE_NOTE=$(git log -1 --pretty=%B)
+#gh release create $new_tag -t $new_tag --repo $repo -n "$RELEASE_NOTE"


### PR DESCRIPTION
## What does this PR do?

* Adds a GitHub action to bump `aws_allowlister/bin/version.py` by patch (major.minor.patch) immediately after a release so the next release will be a new version. This way I don't have to do this manually.
* It also runs on `workflow_dispatch` so I can trigger this from the GitHub actions UI directly.

The process for releasing a new version is now as follows:
* Go to the releases tab, observe that the release drafter GitHub action has created a draft release for you. Hit publish as you did before. Observe that after the new version is published,  the path `aws_allowlister/bin/version.py` will be updated. This way, you can just publish new versions by following the release drafter workflow without having to update the version.py file at all.

## What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/3422255/115573090-7829e780-a28e-11eb-9e62-78533b13d590.png)

## Completion checklist

- [x] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/aws-allowlister/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
